### PR TITLE
Can't call "teuton play" with absolute paths

### DIFF
--- a/lib/project/name_file_finder.rb
+++ b/lib/project/name_file_finder.rb
@@ -7,7 +7,7 @@ require_relative '../application'
 # * find_filenames_for, verbose, verboseln
 module NameFileFinder
   def self.find_filenames_for(relpathtofile)
-    pathtofile = File.join(Application.instance.running_basedir, relpathtofile)
+    pathtofile = File.absolute_path(relpathtofile)
 
     # Define:
     #   script_path, must contain fullpath to DSL script file

--- a/tests/project/name_file_finder_test.rb
+++ b/tests/project/name_file_finder_test.rb
@@ -21,6 +21,17 @@ class NameFileFinderTest < Minitest::Test
     assert_equal c, app.config_path
     assert_equal 'example-01', app.test_name
 
+    # Simple mode, files exists (using absolute path)
+    basedir = app.running_basedir
+    absolute_path = File.join(basedir, 'tests/files/example-01.rb')
+    NameFileFinder.find_filenames_for(absolute_path)
+    b = File.join(basedir, 'tests/files/example-01.rb')
+    c = File.join(basedir, 'tests/files/example-01.yaml')
+    assert_equal a, app.project_path
+    assert_equal b, app.script_path
+    assert_equal c, app.config_path
+    assert_equal 'example-01', app.test_name
+
     # Simple mode, files exists with JSON
     NameFileFinder.find_filenames_for('tests/files/example-04.rb')
     basedir = app.running_basedir


### PR DESCRIPTION
Teuton fails when calling it with an absolute path (**teuton play {absolute_path}**)

Added a failing test to prove it:
```
  1) Failure:
NameFileFinderTest#test_simple_mode_find_filenames_for [/home/siga01.stic.ull.es/53/alu0101015255/teuton/tests/project/name_file_finder_test.rb:30]:
--- expected
+++ actual
@@ -1 +1 @@
-"/home/siga01.stic.ull.es/53/alu0101015255/teuton/tests/files"
+"/home/siga01.stic.ull.es/53/alu0101015255/teuton/home/siga01.stic.ull.es/53/alu0101015255/teuton/tests/files"
```

The path is being treated as a relative path instead of an absolute one (Reason why the path seems to be repeated twice)

Changing the function `File.join()` to `File.absolute_path()` solves the issue.

P.S: Tested on Ubuntu 18.04. Can't test on Windows.

